### PR TITLE
Adding local_to_utc_dst function.

### DIFF
--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -108,12 +108,10 @@ local_to_local(LocalDateTime, TimezoneFrom, TimezoneTo) ->
 local_to_local_dst(LocalDateTime, TimezoneFrom, TimezoneTo) ->
    case local_to_utc_dst(LocalDateTime, TimezoneFrom) of
       Date = {{_,_,_},{_,_,_}} ->
-         io:format("ha", []),
          utc_to_local(Date, TimezoneTo);
       [FirstDate, SecondDate] ->
          [utc_to_local(FirstDate, TimezoneTo), utc_to_local(SecondDate, TimezoneTo)];
       Res ->
-         io:format("Blah", []),
          Res
    end.
 


### PR DESCRIPTION
Currently, converting a time that occurs twice in a given region will only give one UTC/GMT time back, rather than two. That is, 1 AM November 3rd occurs twice in "America/New York", but the erlang_localtime library provides only one value back, GMT 6 (rather than GMT 5 and 6).

I'd like a way to get both. Erlang's calendar module provides this through a second function call, local_time_to_universal_time_dst (whereas the call that returns just one time omits the DST part), which seems a reasonable approach.

Pull request refactors out local_to_utc into also supporting a local_to_utc_dst function,
