### PR TITLE
Add list_timezones/0, export adjust_datetime/2, and allow Timezone name as strings in localtime_dst:check

### DIFF
--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -1,3 +1,5 @@
+%% vim: ts=4 sw=4 et
+%%
 %% Copyright (C) 07/01/2010 Dmitry S. Melnikov (dmitryme@gmail.com)
 %%
 %% This program is free software; you can redistribute it and/or
@@ -13,6 +15,7 @@
 %% You should have received a copy of the GNU General Public License
 %% along with this program; if not, write to the Free Software
 %% Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+%%
 -module(localtime).
 
 -author("Dmitry Melnikov <dmitryme@gmail.com>").
@@ -29,6 +32,9 @@
      ,tz_name/2
      ,tz_shift/2
      ,tz_shift/3
+     ,get_timezone/1
+     ,list_timezones/0
+     ,adjust_datetime/2
   ]).
 
 % utc_to_local(UtcDateTime, Timezone) -> LocalDateTime | [LocalDateTime, DstLocalDateTime] | {error, ErrDescr}
@@ -197,13 +203,25 @@ tz_shift(LocalDateTime, TimezoneFrom, TimezoneTo) ->
          Err
    end.
 
-% =======================================================================
-% privates
-% =======================================================================
+get_timezone(TimeZone) ->
+   case dict:find(TimeZone, ?tz_index)  of
+      error ->
+         TimeZone;
+      {ok, [TZName | _]} ->
+            TZName
+    end.
+
+list_timezones() ->
+    dict:fetch_keys(?tz_index).
 
 adjust_datetime(DateTime, Minutes) ->
    Seconds = calendar:datetime_to_gregorian_seconds(DateTime) + Minutes * 60,
    calendar:gregorian_seconds_to_datetime(Seconds).
+
+% =======================================================================
+% privates
+% =======================================================================
+
 
 invert_shift(Minutes) ->
    -Minutes.
@@ -220,10 +238,3 @@ fmt_shift({'-', H, M}) ->
 fmt_shift(Any) ->
    throw(Any).
 
-get_timezone(TimeZone) ->
-   case dict:find(TimeZone, ?tz_index)  of
-      error ->
-         TimeZone;
-      {ok, [TZName | _]} ->
-            TZName
-   end.

--- a/src/localtime_dst.erl
+++ b/src/localtime_dst.erl
@@ -1,3 +1,5 @@
+%% vim: ts=4 sw=4 et
+%%
 %% Copyright (C) 07/01/2010 Dmitry S. Melnikov (dmitryme@gmail.com)
 %%
 %% This program is free software; you can redistribute it and/or
@@ -18,6 +20,9 @@
 
 -author("Dmitry Melnikov <dmitryme@gmail.com>").
 
+-include("tz_database.hrl").
+-include("tz_index.hrl").
+
 -export(
    [
       check/2
@@ -28,7 +33,15 @@
 
 % check(DateTime, TimeZone) -> is_in_dst | is_not_in_dst | ambiguous_time | time_not_exists
 %  DateTime = DateTime()
-%  TimeZone = tuple()
+%  TimeZone = tuple() | string()
+check(DateTime, Timezone) when is_list(Timezone) ->
+    case lists:keyfind(localtime:get_timezone(Timezone), 1, ?tz_database) of
+        false ->
+            {error, unknown_tz};
+        TZ -> 
+            check(DateTime, TZ)
+    end;
+        
 check({Date = {Year, _, _},Time}, {_, _, _, _Shift, DstShift, DstStartRule, DstStartTime, DstEndRule, DstEndTime}) ->
    DstStartDay = get_dst_day_of_year(DstStartRule, Year),
    DstEndDay = get_dst_day_of_year(DstEndRule, Year),


### PR DESCRIPTION
Hi!

Thank you for the erlang_localtime package. I use it to handle timezones along with date-and-time formatting in a package called [qdate](http://github.com/choptastic/qdate).

Anyway, I've been using it for a while relying on one of my own forks (not wanting to bother you with my specific changes), but I figured it's probably better to try to get it all together in one package rather than have lots of forks.

Anyway, here are a few changes I've been using, which have been squashed for easy merging.

Added a function list_timezones/0: This merely returns a list of all timezones by name, so the user doesn't have to include the header file in their code.

Export the adjust_datetime/2 function: It was easiest to simply export this function for use in qdate so that it can simply adjust by minutes rather than by TZ name, but retain your erlang_localtime logic @ https://github.com/choptastic/qdate/blob/master/src/qdate.erl#L340

Allow strings in localtime_dst:check, this just adds a wrapper function to allow localtime_dst:check to accept a string as the timezone name, look it up in the timezone database, and then recall itself with the found timezone.

Also, I added vim modelines to the heads so that tabs-to-spaces don't become an issue for vim users who might also wish to contribute.

Thanks again for the great tool!

-Jesse