### PR TITLE
Handle fmt_shift(0) -> 0.

### DIFF
--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -205,6 +205,8 @@ fmt_shift({'+', H, M}) ->
    H * 60 + M;
 fmt_shift({'-', H, M}) ->
    -(H * 60 + M);
+fmt_shift(0) ->
+   0;
 fmt_shift(Any) ->
    throw(Any).
 


### PR DESCRIPTION
`tz_shift(_, "UTC")` returns 0, but fmt_shift/1 previously did not handle that. (Dialyzer noticed and complained.) An alternative fix would be for `tz_shift(_, "UTC")` to return `{'+', 0, 0}`. 