### PR TITLE
Fix tz_shift/{2,3} for UTC

### DIFF
--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -123,8 +123,6 @@ local_to_local_dst(LocalDateTime, TimezoneFrom, TimezoneTo) ->
 %  DstAbbr = String()
 %  DstName = String()
 %  ErrDesc = atom(), unknown_tz
-tz_name(_UtcDateTime, "UTC") ->
-   {"UTC", "UTC"};
 tz_name(LocalDateTime, Timezone) ->
    case lists:keyfind(get_timezone(Timezone), 1, ?tz_database) of
       false ->
@@ -153,8 +151,6 @@ tz_name(LocalDateTime, Timezone) ->
 %  Hours = Minutes = Integer(),
 %  {Shift, DstShift} - returns, when shift is ambiguous
 %  ErrDesc = atom(), unknown_tz
-tz_shift(_UtcDateTime, "UTC") ->
-   {'+', 0, 0};
 tz_shift(LocalDateTime, Timezone) ->
    case lists:keyfind(get_timezone(Timezone), 1, ?tz_database) of
       false ->

--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -154,7 +154,7 @@ tz_name(LocalDateTime, Timezone) ->
 %  {Shift, DstShift} - returns, when shift is ambiguous
 %  ErrDesc = atom(), unknown_tz
 tz_shift(_UtcDateTime, "UTC") ->
-   0;
+   {'+', 0, 0};
 tz_shift(LocalDateTime, Timezone) ->
    case lists:keyfind(get_timezone(Timezone), 1, ?tz_database) of
       false ->


### PR DESCRIPTION
`0` isn't really a valid shift, nor would fmt_shift/1 accept it.